### PR TITLE
Version 0.4.0 - 7/12/2015

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,13 +30,16 @@ ClassLength:
   Max: 1000
 
 AbcSize:
-  Max: 40
+  Max: 62
 
 ParameterLists:
   Max: 15
   CountKeywordArgs: true
 
 StringLiterals:
+  Enabled: false
+
+Style/SpecialGlobalVars:
   Enabled: false
 
 Style/SignalException:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.0 (7/12/2015)
+- Added http_port to one_image resource so that port other than 8066 (default) can be used to upload images.
+- Fixed error message in one_image resource
+- Removed :credentials and :secret_file support as driver options.  It uses profiles now.
+- Fixed ssh timeout.  Now the :timeout will be applied to each ssh command and overall timeout to establish
+  a ssh session is 5 min.
+- one_image now takes 'download_url' as an optional attribute.  'image_file' still takes precedence over 
+  'download_url'.  If 'download_url' is specified then that location is used for image and it will not try 
+  to start HTTP server locally.
+- Changed default port for HTTP server in one_image to be 8066 instead of previously used port 80.  This is to
+  avoid collision with existing web servers running on the host.
+- Added :mode attribute to one_image, one_template and one_vnet resources.
+- Added bootstrap_options[:mode] so that machines can be created with different permissions
+
 ## 0.3.4 (10/29/2015)
 - Yanked version 0.3.3 from rubygems due to internal homepage link in gemspec
 - Need to release version 0.3.4 to reupload to rubygems.org
@@ -8,7 +22,7 @@
 - Changed driver_url to include profiles.  Without profiles machine_file was unable to recreate the driver
   and subsequently failed. The new driver_url format is:
   opennebula:<endpoint_url>:<profile>
-  where profile is stored in ~/.one/one_config or ENV['ONE_CONFIG'] or /var/lig/one/.one/one_config file
+  where profile is stored in ~/.one/one_config or ENV['ONE_CONFIG'] or /var/lib/one/.one/one_config file
 - Added check for machine :destroy to verify that the VM is in DONE state.  If not successful after 20 seconds
   it will fail.
 - opennebula 4.14 is not backwards compatible so there is a new gem dependency 'opennebula <4.14'.
@@ -24,12 +38,12 @@
 ## 0.3.0 (9/23/2015)
 - Added one_user resource
 - Added support for machine shutdown.  Before 'machine :stop' would call the stop method on the VM,
-  now this behaviour can be changed to call vm.shutdown by specifying :bootstrap_options[:is_shutdown] = true
+  now this behavior can be changed to call vm.shutdown by specifying :bootstrap_options[:is_shutdown] = true
 - Added optional bootstrap_option flag [:unique_name] for validation of unique machine names in OpenNebula
 - Removed :instantiate from one_template resource, because it is a duplicate or 'machine :template'
 - Fixed warnings in providers regarding resource_names
 - Removed support for :ssh_execute_options => { :prefix => 'sudo '} in favour of :sudo => true
-- Added licencse headers
+- Added license headers
 - Modified permissions for downloaded qcow images to be 777
 - Added error message when :bootstrap_options are not defined
 - Added missing :cache attribute to one_image resource
@@ -42,7 +56,7 @@
 
 ```json
 :ssh_username => 'local',
-	:ssh_options => {
+    :ssh_options => {
 	:keys_only => false,
 	:forward_agent => true,
 	:use_agent => true,
@@ -66,7 +80,7 @@
 
 ## 0.2.1 (7/11/2015)
 
-- Added upload/downlod functionality to one_image
+- Added upload/download functionality to one_image
 
 ## 0.1.0 (4/30/2015)
 

--- a/README.md
+++ b/README.md
@@ -45,27 +45,6 @@ A sample one_config file would look like this:
 }
 ```
 
-If no profile is specified the driver will attempt to read and use the ```ENV['ONE_AUTH']``` file or ```~/.one/one_auth``` or ```/var/lib/one/.one/one_auth```.
-The driver is still backward compatible with previous format and passing ```:secret_file``` or ```:credentials``` in```:driver_options```.
-
-Additional options to OpenNebual client can be passed vi ```:one_options```.
-
-```ruby
-with_driver "opennebula:http://1.2.3.4/endpoint:port",
-  :credentials => "<username>:<text_password>",
-  :one_options => { :timeout => 3 }
-```
-
-or
-
-```ruby
-with_driver "opennebula:http://1.2.3.4/endpoint:port",
-  :secret_file => "<local_path_to_file_with_credentials>",
-  :one_options => { :timeout => 3 }
-```
-
-If additional OpenNebula client options need to be passed they can be specified as a hash ```:one_options => {}```.  
-
 In context of OpenNebula ```machine``` resource will take the following additional options:
 
 ```ruby
@@ -79,6 +58,7 @@ machine_options {
 		:enforce_chef_fqdn => [TrueClass, FalseClass] flag indicating if fqdn names should be used for machine names
 		:is_shutdown => [TrueClass, FalseClass] call vm.shutodwn instead of vm.stop during :stop action
 		:shutdown_hard => [TrueClass, FalseClass] flag indicating hard or soft shutdown
+    :mode => String octed to set permissions to the machine
 	},
 	:sudo => true,
 	:ssh_username => 'local',
@@ -109,6 +89,7 @@ This resource will allow to create and delete OpenNebula templates.
 ```ruby
   :template => Hash defining OpenNebula template
   :template_file => String location of the VM template file
+  :mode => String octet to set permissions
 ```
 
 ### Actions
@@ -201,6 +182,8 @@ This resource will manage images within OpenNebula.
   :driver => String Image driver eq. 'qcow2'
   :machine_id => [String, Integer] id of the machine (VM) for disk attach
   :disk_id => [String, Integer] id or name of the disk to attach/snapshot
+  :mode => String octet to set permissions
+  :http_port => Integer port number to start local HTTP server at, for :image_file uploads. Default: 8066
 ```
 
 ### Actions
@@ -272,20 +255,31 @@ one_image "snapshot-img" do
 end
 ```
 
-#### 6. Upload a local qcow2 image file to OpenNebula
+#### 6. Upload a local qcow2 image file to OpenNebula, starting HTTP server on port 4567
 
 ```ruby
-one_image "snapshot-img" do
+one_image "upload-img" do
   datastore_id 103
   image_file "/local/path/to/qcow/image/file"
   img_driver "qcow2"
   type "OS"
+  http_port 4567
   description "This is my cool qcow image"
   action :upload
 end
 ```
 
-#### 7. Download a 'boggi-test-img' and store it in /home/local/my-image.qcow2.  Download URL read from ENV[ONE_DOWNLOAD] variable. It will be stored locally in Chef::Config[:file_cache_path]/boggi-test-img.qcow2.
+#### 7. Upload a qcow2 image file residing on a different host to OpenNebula
+
+```ruby
+one_image "upload-img" do
+  datastore_id 103
+  download_url "http://my.image.host/path/to/qcow/image/file"
+  action :upload
+end
+```
+
+#### 8. Download a 'boggi-test-img' and store it in /home/local/my-image.qcow2.  Download URL is read from ENV[ONE_DOWNLOAD] variable. It will be stored locally in Chef::Config[:file_cache_path]/boggi-test-img.qcow2.
 
 ```ruby
 one_image "boggi-test-img" do
@@ -293,7 +287,7 @@ one_image "boggi-test-img" do
 end
 ```
 
-#### 8. Download image ID 12345 and store it in /tmp/image.qcow2.
+#### 9. Download image ID 12345 and store it in /tmp/image.qcow2.
 
 ```ruby
 one_image "boggi-test-img" do
@@ -319,6 +313,7 @@ This resource will allow to create and delete OpenNebula vnets.
   :mac_ip => String ip or mac address
   :template_file => String local file containing the template of a new vnet
   :cluster_id => Integer cluster in which to create a vnet
+  :mode => String octet to set permissions
 ```
 
 ### Actions

--- a/lib/chef/provider/one_template.rb
+++ b/lib/chef/provider/one_template.rb
@@ -57,6 +57,7 @@ class Chef
             template_str = new_driver.one.create_template(new_resource.template) if new_resource.template
             template_str << "\nNAME=\"#{new_resource.name}\""
             @template = new_driver.one.allocate_template(template_str)
+            new_driver.one.chmod_resource(@template, new_resource.mode)
             @new_resource.updated_by_last_action(true)
           end
         end

--- a/lib/chef/provider/one_vnet.rb
+++ b/lib/chef/provider/one_vnet.rb
@@ -53,6 +53,7 @@ class Chef
             vnet = new_driver.one.allocate_vnet(template_str, @new_resource.cluster_id)
             Chef::Log.debug(template_str)
             fail "failed to create vnet '#{@new_resource.name}': #{vnet.message}" if OpenNebula.is_error?(vnet)
+            new_driver.one.chmod_resource(vnet, new_resource.mode)
             @new_resource.updated_by_last_action(true)
           end
         end

--- a/lib/chef/provisioning/opennebula_driver/credentials.rb
+++ b/lib/chef/provisioning/opennebula_driver/credentials.rb
@@ -69,8 +69,12 @@ class Chef
           begin
             content_hash = JSON.parse(File.read(file), :symbolize_names => true)
             content_hash.each { |k, v| json[k.to_s] = v }
-          rescue Exception => e
-            Chef::Log.warn("Failed to read and parse config file #{file}: #{e.message}")
+          rescue StandardError => e_file
+            Chef::Log.warn("Failed to read config file #{file}: #{e_file.message}")
+          rescue JSON::ParserError => e_json
+            Chef::Log.warn("Failed to parse config file #{file}: #{e_json.message}")
+          rescue
+            Chef::Log.warn("Failed to read or parse config file #{file}: #{$!}")
           end
           @credentials.merge!(json)
         end

--- a/lib/chef/provisioning/opennebula_driver/version.rb
+++ b/lib/chef/provisioning/opennebula_driver/version.rb
@@ -24,7 +24,7 @@ class Chef
     # Extending module.
     #
     module OpenNebulaDriver
-      VERSION = '0.3.4'
+      VERSION = '0.4.0'
     end
   end
 end

--- a/lib/chef/resource/one_image.rb
+++ b/lib/chef/resource/one_image.rb
@@ -42,6 +42,7 @@ class Chef
       attribute :prefix, :kind_of => String, :equal_to => %w(vd xvd sd hd)
       attribute :persistent, :kind_of => [TrueClass, FalseClass]
       attribute :public, :kind_of => [TrueClass, FalseClass]
+      attribute :mode, :regex => [/^\d\d\d$/]
       attribute :disk_type, :kind_of => String
       attribute :source, :kind_of => String
       attribute :target, :kind_of => String
@@ -49,10 +50,10 @@ class Chef
       attribute :disk_id, :kind_of => [String, Integer]
       attribute :image_file, :kind_of => String
       attribute :cache, :kind_of => String
-      attribute :driver
-
       attribute :download_url, :kind_of => String
       attribute :image_id, :kind_of => Integer
+      attribute :http_port, :kind_of => Integer, :default => 8066
+      attribute :driver
 
       def initialize(*args)
         super

--- a/lib/chef/resource/one_template.rb
+++ b/lib/chef/resource/one_template.rb
@@ -30,6 +30,7 @@ class Chef
 
       attribute :template, :kind_of => Hash
       attribute :template_file, :kind_of => String
+      attribute :mode, :regex => [/^\d\d\d$/]
       attribute :driver
 
       actions :create, :delete

--- a/lib/chef/resource/one_vnet.rb
+++ b/lib/chef/resource/one_vnet.rb
@@ -36,6 +36,7 @@ class Chef
       attribute :ar_id, :kind_of => Integer
       attribute :template_file, :kind_of => String
       attribute :cluster_id, :kind_of => Integer
+      attribute :mode, :regex => [/^\d\d\d$/]
 
       attribute :driver
 


### PR DESCRIPTION
1. Added http_port to one_image resource so that port other than 8066 (default) can be used to upload images.
2. Replaced :credentials and :secret_file driver options with profiles.
3. Fixed ssh timeout; :timeout will be applied to each ssh command and overall timeout to establish a ssh session is 5 min.
4. one_image now takes 'download_url' as an optional attribute; 'image_file' still takes precedence over 'download_url'. If 'download_url' is specified then that location is used for image and it will not try to start HTTP server locally.
5. Changed default port for HTTP server in one_image to be 8066 instead of previously used port 80.
6. Added :mode attribute to one_image, one_template and one_vnet resources.
7. Added bootstrap_options[:mode] so that machines can be created with different permissions.
