### PR TITLE
Version 0.4.3 - 2/12/2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 0.4.2 (8/12/2015)
+## 0.4.3 (2/12/2016)
+- Fixed get_pool method to process symbols correctly
+- Update driver and resources to use new get_pool method
+- Add 4.14 support
+- Deprecate :enforce_chef_fqdn
+- Added template support for embedded quotation marks
+- Added ssh_gateway support
+- Add :vm_name option to rename VM in OpenNebula UI
+
+## 0.4.1 (8/12/2015)
 - Fixed one_vnet_lease :hold action logic.
 
 ## 0.4.0 (7/12/2015)

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ machine_options {
 		:template_name => String name of the OpenNebula template to use
 		:template_id => Integer id of the OpenNebula template to use
 		:template_options => Hash values to be merged with VM template
-		:enforce_chef_fqdn => [TrueClass, FalseClass] flag indicating if fqdn names should be used for machine names
 		:is_shutdown => [TrueClass, FalseClass] call vm.shutodwn instead of vm.stop during :stop action
 		:shutdown_hard => [TrueClass, FalseClass] flag indicating hard or soft shutdown
     :mode => String octed to set permissions to the machine
 	},
 	:sudo => true,
 	:ssh_username => 'local',
+	:ssh_gateway => 'gary@myproxy.net',
 	:ssh_options => {
 	  Hash containing SSH options as specified by net-ssh gem
 	  please see https://github.com/net-ssh/net-ssh for all options
@@ -71,9 +71,15 @@ machine_options {
 	  :keys => [ File.open(File.expand_path('~/.ssh/id_rsa_new')).read ]
 	  :keys_only => false,
 	  :forward_agent => true,
+	  :proxy => 'ssh myproxy.net nc %h %p',
 	  :use_agent => true,
 	  :user_known_hosts_file => '/dev/null'
 	}
+  :vm_name => [Symbol, String] Change how the machine shows up in OpenNebula UI and CLI tools.
+			       Use :short to rename the machine to the short hostname.
+			       Use a string to rename the machine to an arbitrary name.
+			       Note this does not change the hostname of the machine, it
+			       simply renames the VM in OpenNebula.
   :connection_timeout => [Integer] max wait time to establish connection
 }
 ```
@@ -503,24 +509,21 @@ example:
 
 ## <a name="authors"></a> Authors
 
-Created by [Bogdan Buczynski][author] (<bbuczynski@blackberry.com>)
+Created by [Bogdan Buczynski](https://github.com/bbuczynski) (<pikus1@gmail.com>)
 
 ## <a name="maintainers"></a> Maintainers
 
 Maintained by
-  * [Bogdan Buczynski][author] (<bbuczynski@blackberry.com>)
-  * [Philip Oliva][maintainer] (<philoliva8@gmail.com>)
-  * [Andrew J. Brown][maintainer] (<anbrown@blackberry.com>)
-  * [Evgeny Yurchenko][maintainer] (<eyurchenko@blackberry.com>)
+  * [Andrew J. Brown](https://github.com/andrewjamesbrown) (<anbrown@blackberry.com>)
+  * [Bogdan Buczynski](https://github.com/bbuczynski) (<pikus1@gmail.com>)
+  * [Dongyu 'Gary' Zheng](https://github.com/dongyuzheng) (<garydzheng@gmail.com>)
+  * [Evgeny Yurchenko](https://github.com/EYurchenko) (<eyurchenko@blackberry.com>)
+  * [Phil Oliva](https://github.com/poliva83) (<philoliva8@gmail.com>)
 
 ## <a name="license"></a> License
 
 Apache 2.0 (see [LICENSE][license])
 
-[author]:           https://github.com/bbuczynski
-[maintainer]:       https://github.com/poliva83
-[maintainer]:       https://github.com/andrewjamesbrown
-[maintainer]:       https://github.com/EYurchenko
 [issues]:           https://github.com/blackberry/chef-provisioning-opennebula/issues
 [license]:          https://github.com/blackberry/chef-provisioning-opennebula/blob/master/LICENSE
 [repo]:             https://github.com/blackberry/chef-provisioning-opennebula

--- a/chef-provisioning-opennebula.gemspec
+++ b/chef-provisioning-opennebula.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ 'README.md', 'LICENSE' ]
   s.summary = 'Driver for creating OpenNebula instances in Chef Provisioning.'
   s.description = s.summary
-  s.authors = [ 'Andrew J. Brown', 'Bogdan Buczynski', 'Evgeny Yurchenko', 'Phil Oliva' ]
-  s.email = [ 'anbrown@blackberry.com', 'bbuczynski@blackberry.com', 'eyurchenko@blackberry.com', 'poliva@blackberry.com' ]
+  s.authors = [ 'Andrew J. Brown', 'Bogdan Buczynski', 'Dongyu \'Gary\' Zheng', 'Evgeny Yurchenko', 'Phil Oliva' ]
+  s.email = [ 'anbrown@blackberry.com', 'bbuczynski@blackberry.com', 'garydzheng@gmail.com', 'eyurchenko@blackberry.com', 'poliva@blackberry.com' ]
   s.homepage = 'https://github.com/blackberry/chef-provisioning-opennebula'
 
   s.add_dependency 'chef'
   s.add_dependency 'chef-provisioning', '> 0.15'
-  s.add_dependency 'opennebula', '~> 4.10', '< 4.14'
+  s.add_dependency 'opennebula', '~> 4.10', '< 5'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/lib/chef/provider/one_template.rb
+++ b/lib/chef/provider/one_template.rb
@@ -1,4 +1,4 @@
-# Copyright 2015, BlackBerry, Inc.
+# Copyright 2015, BlackBerry, Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,68 +28,145 @@ class Chef
 
       provides :one_template
 
-      attr_reader :template
+      attr_reader :uname
+      attr_reader :equal_template
+      attr_reader :equal_mode
+      attr_reader :current_id
 
       def whyrun_supported?
         true
       end
 
       def load_current_resource
-      end
+        driver = self.driver
+        @uname = uname
+        @current_resource = Chef::Resource::OneTemplate.new(new_resource.name,
+                                                            run_context)
+        @current_resource.name(new_resource.name)
+        template = driver.one.get_resource(:template,
+                                           :name => @current_resource.name,
+                                           :uname => @uname)
+        @current_resource.exists = !template.nil?
 
-      def action_handler
-        @action_handler ||= Chef::Provisioning::ChefProviderActionHandler.new(self)
-      end
+        return unless @current_resource.exists
 
-      def exists?
-        new_driver = driver
-        @template = new_driver.one.get_resource('tpl', :name => new_resource.name)
-        !@template.nil?
+        new_resource_template = @new_resource.template_file.nil? ?
+            @new_resource.template :
+            driver.one.template_from_file(@new_resource.template_file)
+
+        @current_id = template.to_hash['VMTEMPLATE']['ID'].to_i
+        @current_resource.template(template.to_hash['VMTEMPLATE']['TEMPLATE'])
+        @current_resource.mode(get_mode(template))
+        @equal_template = @current_resource.template == new_resource_template
+        @equal_mode = @current_resource.mode == new_resource.mode
+        @current_resource.equal = @equal_template && @equal_mode
       end
 
       action :create do
-        if exists?
-          action_handler.report_progress "template '#{new_resource.name}' already exists - nothing to do"
-        else
-          fail "Missing attribute 'template_file' or 'template'" if !new_resource.template_file && !new_resource.template
-          action_handler.perform_action "create template '#{new_resource.name}'" do
-            template_str = File.read(new_resource.template_file) if new_resource.template_file
-            template_str = new_driver.one.create_template(new_resource.template) if new_resource.template
-            template_str << "\nNAME=\"#{new_resource.name}\""
-            @template = new_driver.one.allocate_template(template_str)
-            new_driver.one.chmod_resource(@template, new_resource.mode)
-            @new_resource.updated_by_last_action(true)
+        template_str = create_template
+
+        unless @current_resource.equal
+          if @current_resource.exists
+            unless @equal_template
+              converge_by "update template content on '#{new_resource.name}'" do
+                driver.one.update_template(@current_id, template_str)
+              end
+            end
+            unless @equal_mode
+              converge_by('update template permissions on ' \
+                "'#{new_resource.name}' to #{new_resource.mode}") do
+                template = driver.one.get_resource(:template,
+                                                   :name => @current_resource.name,
+                                                   :uname => @uname)
+                driver.one.chmod_resource(template, new_resource.mode)
+              end
+            end
+          else
+            converge_by("create template '#{new_resource.name}'") do
+              create_one_template(template_str)
+            end
           end
+          new_resource.updated_by_last_action(true)
+        end
+      end
+
+      action :create_if_missing do
+        template_str = create_template
+
+        unless @current_resource.exists
+          converge_by("create template '#{new_resource.name}'") do
+            create_one_template(template_str)
+          end
+          new_resource.updated_by_last_action(true)
         end
       end
 
       action :delete do
-        if !exists?
-          action_handler.report_progress "template '#{new_resource.name}' does not exists - nothing to do"
-        else
-          action_handler.perform_action "delete template '#{new_resource.name}'" do
-            @template.delete
-            @new_resource.updated_by_last_action(true)
-          end
-        end
+        converge_by("delete template '#{new_resource.name}'") do
+          template = driver.one.get_resource(:template,
+                                             :name => @current_resource.name,
+                                             :uname => @uname)
+          template.delete
+          new_resource.updated_by_last_action(true)
+        end if @current_resource.exists
       end
 
       protected
 
       def driver
-        if current_driver && current_driver.driver_url != new_driver.driver_url
-          fail "Cannot move '#{machine_spec.name}' from #{current_driver.driver_url} to #{new_driver.driver_url}: machine moving is not supported.  Destroy and recreate."
+        current_driver = begin
+          if new_resource.driver
+            run_context.chef_provisioning.driver_for(new_resource.driver)
+          elsif run_context.chef_provisioning.current_driver
+            run_context.chef_provisioning.driver_for(run_context.chef_provisioning.current_driver)
+          end
         end
-        fail "Driver not specified for one_image #{new_resource.name}" unless new_driver
-        new_driver
+        fail "Driver not specified for one_template  #{new_resource.name}" unless current_driver
+        current_driver
       end
 
-      def new_driver
-        run_context.chef_provisioning.driver_for(new_resource.driver)
+      def create_one_template(template_str)
+        unless new_resource.template.key?('NAME')
+          template_str << "\n" << 'NAME="' << new_resource.name << '"'
+        end
+        driver.one.allocate_template(template_str)
+        template = driver.one.get_resource(:template,
+                                           :name => @current_resource.name,
+                                           :uname => @uname)
+        driver.one.chmod_resource(template, new_resource.mode)
       end
 
-      def current_driver
-        run_context.chef_provisioning.driver_for(run_context.chef_provisioning.current_driver) if run_context.chef_provisioning.current_driver
+      def create_template
+        if new_resource.template_file && new_resource.template.size > 0
+          fail("Attributes 'template_file' and 'template' are mutually " \
+               'exclusive.')
+        elsif new_resource.template_file
+          ::File.read(new_resource.template_file)
+        elsif new_resource.template.size > 0
+          driver.one.create_template(new_resource.template)
+        else
+          fail("Missing attribute 'template_file' or 'template' in " \
+               'resource block.')
+        end
+      end
+
+      def get_mode(template)
+        perms = template.to_hash['VMTEMPLATE']['PERMISSIONS']
+        mode = 0
+        %w(OWNER_U OWNER_M OWNER_A GROUP_U GROUP_M GROUP_A
+           OTHER_U OTHER_M OTHER_A).each do |m|
+          mode += perms[m].to_i
+          mode = mode << 1
+        end
+        mode = mode >> 1
+        mode.to_s(8)
+      end
+
+      def uname
+        xml = OpenNebula::User.build_xml(OpenNebula::User::SELF)
+        my_user = OpenNebula::User.new(xml, driver.one.client)
+        my_user.info!
+        my_user.to_hash['USER']['NAME']
       end
     end
   end

--- a/lib/chef/provider/one_user.rb
+++ b/lib/chef/provider/one_user.rb
@@ -36,7 +36,7 @@ class Chef
 
       def exists?(filter)
         new_driver = driver
-        @current_user = new_driver.one.get_resource('user', filter)
+        @current_user = new_driver.one.get_resource(:user, filter)
         Chef::Log.debug("user '#{filter}' exists: #{!@current_user.nil?}")
         !@current_user.nil?
       end

--- a/lib/chef/provider/one_vnet.rb
+++ b/lib/chef/provider/one_vnet.rb
@@ -36,7 +36,7 @@ class Chef
 
       def exists?(filter)
         new_driver = driver
-        @current_vnet = new_driver.one.get_resource('vnet', filter)
+        @current_vnet = new_driver.one.get_resource(:virtualnetwork, filter)
         Chef::Log.debug("VNET '#{filter}' exists: #{!@current_vnet.nil?}")
         !@current_vnet.nil?
       end

--- a/lib/chef/provider/one_vnet_lease.rb
+++ b/lib/chef/provider/one_vnet_lease.rb
@@ -37,7 +37,7 @@ class Chef
       def exists?
         new_driver = driver
         filter = { @new_resource.vnet.is_a?(Integer) ? :id : :name => @new_resource.vnet }
-        @current_vnet = new_driver.one.get_resource('vnet', filter)
+        @current_vnet = new_driver.one.get_resource(:virtualnetwork, filter)
         fail "vnet '#{@new_resource.vnet}' does not exist" if @current_vnet.nil?
         @current_vnet.info!
         hash = @current_vnet.to_hash

--- a/lib/chef/provisioning/opennebula_driver/version.rb
+++ b/lib/chef/provisioning/opennebula_driver/version.rb
@@ -24,7 +24,7 @@ class Chef
     # Extending module.
     #
     module OpenNebulaDriver
-      VERSION = '0.4.2'
+      VERSION = '0.4.3'
     end
   end
 end

--- a/lib/chef/resource/one_template.rb
+++ b/lib/chef/resource/one_template.rb
@@ -28,18 +28,19 @@ class Chef
     class OneTemplate < Chef::Resource::LWRPBase
       resource_name :one_template
 
-      attribute :template, :kind_of => Hash
-      attribute :template_file, :kind_of => String
-      attribute :mode, :regex => [/^\d\d\d$/]
+      attribute :template, :kind_of => Hash, :default => {}
+      attribute :template_file, :kind_of => String, :default => nil
+      attribute :mode, :regex => [/^[0-7]{3}$/], :default => '600'
       attribute :driver
 
-      actions :create, :delete
+      actions :create, :create_if_missing, :delete
       default_action :create
+
+      attr_accessor :exists
+      attr_accessor :equal
 
       def initialize(*args)
         super
-        @chef_environment = run_context.cheffish.current_environment
-        @chef_server = run_context.cheffish.current_chef_server
         @driver = run_context.chef_provisioning.current_driver
       end
     end


### PR DESCRIPTION
1. Fixed get_pool method to process symbols correctly.
2. Update driver and resources to use new get_pool method.
3. Add 4.14 Opennebula support.
4. Deprecate :enforce_chef_fqdn.
5. Added template support for embedded quotation marks.
6. Added ssh_gateway support.
7. Add :vm_name option to rename VM in OpenNebula UI.

Thanks to following authors for contributing to this release:
- Andrew J. Brown (anbrown@blackberry.com)
- Bogdan Buczynski (pikus1@gmail.com)
- Dongyu 'Gary' Zheng (garydzheng@gmail.com)
