### PR TITLE
Version 0.4.7 - 8/19/2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
+## 0.4.7 (8/5/2016)
+- Added debug info when server_version.rb fails to load 'opennebula' gem, due to bad environment settings
+- Added retries to allocate_machine in case ONE has issues and :bootstrap_options are not specified
+- Removed default CONTEXT['USER_DATA'] attributes for cloud-init
+
 ## 0.4.6 (5/3/2016)
 - Added begin/rescue around convergence_strategy deletion in destroy_machine method to avoid failures
   when the client/node objects are not present
 - Fixed rubocop errors
 
 ## 0.4.5 (4/28/2016)
-- Added OneFlow resources (see readme): one_flow_template, one_flow_service
+- Added OneFlow resources (see README): one_flow_template, one_flow_service
 - Added RSpec tests for OneFlow
 - Fixed RSpec tests for newest chef-client 12.9.38
 - Fixed bug regarding destroying machines when machine_spec.reference is nil

--- a/chef-provisioning-opennebula.gemspec
+++ b/chef-provisioning-opennebula.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'opennebula', '~> 4.10', '< 5'
   s.add_dependency 'rest-client', '~> 1.8'
   s.add_dependency 'json', '~> 1.8', '>= 1.8.3'
+  s.add_dependency 'http-cookie', '>= 1.0.2'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'

--- a/lib/chef/provisioning/opennebula_driver/version.rb
+++ b/lib/chef/provisioning/opennebula_driver/version.rb
@@ -24,7 +24,7 @@ class Chef
     # Extending module.
     #
     module OpenNebulaDriver
-      VERSION = '0.4.6'.freeze
+      VERSION = '0.4.7'.freeze
     end
   end
 end


### PR DESCRIPTION
1. Added debug info when server_version.rb fails to load 'opennebula' gem, due to bad environment settings.
2. Added retries to allocate_machine in case ONE has issues and :bootstrap_options are not specified.
3. Removed default CONTEXT['USER_DATA'] attributes for cloud-init.
